### PR TITLE
Cakefile error from Coffee Script 1.3.x update

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -9,9 +9,9 @@ config = JSON.parse(fs.readFileSync(__dirname+ '/config.json', 'utf-8'))
 # ANSI terminal colors.
 # ----------
 
-red   = '\033[0;31m'
-green = '\033[0;32m'
-reset = '\033[0m'
+red   = `'\033[0;31m'`
+green = `'\033[0;32m'`
+reset = `'\033[0m'`
 
 # Commands
 # ----------


### PR DESCRIPTION
Right now any `cake` command will throw an error.

The new version of Coffee Script requires you to either escape the colors out or use the literal format - see jashkenas/coffee-script#2021.
