### PR TITLE
Fixed deprecated express.createServer() call. 

### DIFF
--- a/server.js
+++ b/server.js
@@ -2,9 +2,9 @@ var url     = require('url'),
     http    = require('http'),
     https   = require('https'),
     fs      = require('fs'),
-	qs      = require('querystring'),
+    qs      = require('querystring'),
     express = require('express'),
-	app     = express();
+    app     = express();
 
 // Load config defaults from JSON file.
 // Environment variables override defaults.


### PR DESCRIPTION
express.createServer() is deprecated.

Changed from

```
express = express.createServer(),
```

to

```
express = require('express'),
app = express(),
```
