### PR TITLE
Create a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM iojs
+
+ADD . /gatekeeper
+WORKDIR /gatekeeper
+RUN npm install
+
+USER nobody
+CMD node server.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM iojs
+FROM node:4.2.1
 
 ADD . /gatekeeper
 WORKDIR /gatekeeper


### PR DESCRIPTION
Thanks for this project! I wrote my own Dockerfile for use with gatekeeper but I figured it might be nice to just have an official one.

When using this, I override using environment variables via `docker run`:

```bash
docker run -it -e OAUTH_CLIENT_ID=NOT_SHOWN_IN_PR -e OAUTH_CLIENT_SECRET=NOT_SHOWN_IN_PR -p 9999:9999 gatekeeper
Configuration
{ oauth_client_id: 'NOT_SHOWN_IN_PR',
  oauth_client_secret: 'NOT_SHOWN_IN_PR',
  oauth_host: 'github.com',
  oauth_port: 443,
  oauth_path: '/login/oauth/access_token',
  oauth_method: 'POST' }
Gatekeeper, at your service: http://localhost:9999
```

It would be *super swell* if you accept this and create an automated build on Docker hub. If not, that's cool too.