### PR TITLE
Added Cache-Control in CORs allowed headers

### DIFF
--- a/server.js
+++ b/server.js
@@ -54,7 +54,7 @@ function authenticate(code, cb) {
 app.all('*', function (req, res, next) {
   res.header('Access-Control-Allow-Origin', '*'); 
   res.header('Access-Control-Allow-Methods', 'GET, OPTIONS'); 
-  res.header('Access-Control-Allow-Headers', 'Content-Type');
+  res.header('Access-Control-Allow-Headers', 'Content-Type, Cache-Control');
   next();
 });
 


### PR DESCRIPTION
Some library set this header to avoid caching, but the browser will deny the COR request with `Request header field Cache-Control is not allowed by Access-Control-Allow-Headers in preflight response.`