### PR TITLE
Set engines node version to ~6.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "express": "~3.16.0"
   },
   "engines": {
-    "node": ">= 0.6.x"
+    "node": "~6.11.1"
   },
   "main": "index",
   "version": "0.1.0"


### PR DESCRIPTION
In `package.json`, I set the following:
```json
"engines": {
    "node": "~6.11.1"
}
```
This is to address Node.js security vulnerability announced here: https://nodejs.org/en/blog/vulnerability/july-2017-security-releases

See issue #32 