### PR TITLE
hide secrets from log output

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,6 +6,10 @@ var url     = require('url'),
     express = require('express'),
     app     = express();
 
+var TRUNCATE_THRESHOLD = 10,
+    REVEALED_CHARS = 3,
+    REPLACEMENT = '***';
+    
 // Load config defaults from JSON file.
 // Environment variables override defaults.
 function loadConfig() {
@@ -53,13 +57,21 @@ function authenticate(code, cb) {
   req.on('error', function(e) { cb(e.message); });
 }
 
+/**
+ * Handles logging to the console.
+ * Logged values can be sanitized before they are logged 
+ * 
+ * @param {string} label - label for the log message
+ * @param {Object||string} value - the actual log message, can be a string or a plain object
+ * @param {boolean} sanitized - should the value be sanitized before logging?
+ */
 function log(label, value, sanitized) {
   value = value || '';
   if (sanitized){
-    if (typeof(value) === 'string' && value.length > 10){
-      console.log(label, value.substring(3,0) + '...');
+    if (typeof(value) === 'string' && value.length > TRUNCATE_THRESHOLD){
+      console.log(label, value.substring(REVEALED_CHARS,0) + REPLACEMENT);
     } else {
-      console.log(label, '...');
+      console.log(label, REPLACEMENT);
     }
   } else {
     console.log(label, value);

--- a/server.js
+++ b/server.js
@@ -92,7 +92,7 @@ app.get('/authenticate/:code', function(req, res) {
   log('authenticating code:', req.params.code, true);
   authenticate(req.params.code, function(err, token) {
     if ( err || !token ) {
-      result = {"error": "bad_code"};
+      result = {"error": err || "bad_code"};
       log(result.error);
     } else {
       result = {"token": token};


### PR DESCRIPTION
I added a log and sanitize function and used that over console.log.

Secret stuff (gh client id, gh client secret, codes and tokens) will be truncated to 3 characters. If the secret is less equal 10 characters or not a string it will be replaced by three dots.

So it logs sthg like this
```
Configuration
oauth_client_id: ac4...
oauth_client_secret: 2ea...
oauth_host: github.com
oauth_port: 443
oauth_path: /login/oauth/access_token
oauth_method: POST
Gatekeeper, at your service: http://localhost:9999
authenticating code: 439...
bad_code
authenticating code: ...
bad_code
authenticating code: 628...
token ee7...
```
closes #34