### PR TITLE
add first test suite

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 
-var {config, app} = require('./server');
+var { config, app } = require('./server');
 
 var port = process.env.PORT || config.port || 9999;
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,8 @@
+
+var {config, app} = require('./server');
+
+var port = process.env.PORT || config.port || 9999;
+
+app.listen(port, null, function (err) {
+  console.log('Gatekeeper, at your service: http://localhost:' + port);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1176 @@
+{
+  "name": "gatekeeper",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "accepts": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.0.7.tgz",
+      "integrity": "sha1-W1AftPBwQwmWTM2wSBclQSCNqxo=",
+      "requires": {
+        "mime-types": "1.0.2",
+        "negotiator": "0.4.7"
+      }
+    },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
+    },
+    "assertion-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "base64-url": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz",
+      "integrity": "sha1-GZ/WYXAqDnt9yubgaYuwicUvbXg="
+    },
+    "basic-auth": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.0.tgz",
+      "integrity": "sha1-ERstn/jk5tE2uMhOpeCWy4c1Fjc="
+    },
+    "basic-auth-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz",
+      "integrity": "sha1-/bC0OWLKe0BFanwrtI/hc9otISI="
+    },
+    "batch": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.1.tgz",
+      "integrity": "sha1-NqS6tZTAUP17UHvKDbMMLZKvT/I="
+    },
+    "body-parser": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.6.7.tgz",
+      "integrity": "sha1-gjBr7K30RUPoJrOQfq6T8CN8Tlw=",
+      "requires": {
+        "bytes": "1.0.0",
+        "depd": "0.4.4",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.2.0",
+        "on-finished": "2.1.0",
+        "qs": "2.2.2",
+        "raw-body": "1.3.0",
+        "type-is": "1.3.2"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "buffer-crc32": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.3.tgz",
+      "integrity": "sha1-u1RRnpXRB8vSQA520MqxRnM22SE="
+    },
+    "bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
+      "integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g="
+    },
+    "chai": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.0.2",
+        "deep-eql": "0.1.3",
+        "type-detect": "1.0.0"
+      }
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "commander": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-1.3.2.tgz",
+      "integrity": "sha1-io8w7GcKb91kr1LxkUuQfXnq1bU=",
+      "requires": {
+        "keypress": "0.1.0"
+      }
+    },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
+    },
+    "compressible": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-1.1.1.tgz",
+      "integrity": "sha1-I7ceqQ6mxqZiiXAakYGCwk0HKe8="
+    },
+    "compression": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.0.11.tgz",
+      "integrity": "sha1-aXAM8e6JY0VDVqwZKm5ekeIyv/s=",
+      "requires": {
+        "accepts": "1.0.7",
+        "bytes": "1.0.0",
+        "compressible": "1.1.1",
+        "debug": "1.0.4",
+        "on-headers": "1.0.1",
+        "vary": "1.0.1"
+      },
+      "dependencies": {
+        "vary": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
+          "integrity": "sha1-meSYFWaihhGN+yuBc1ffeZM3bRA="
+        }
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "connect": {
+      "version": "2.25.10",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-2.25.10.tgz",
+      "integrity": "sha1-GDs7VQaax81LWf/dh8xMxff/qKc=",
+      "requires": {
+        "basic-auth-connect": "1.0.0",
+        "body-parser": "1.6.7",
+        "bytes": "1.0.0",
+        "compression": "1.0.11",
+        "connect-timeout": "1.2.2",
+        "cookie": "0.1.2",
+        "cookie-parser": "1.3.2",
+        "cookie-signature": "1.0.4",
+        "csurf": "1.4.1",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "errorhandler": "1.1.1",
+        "express-session": "1.7.6",
+        "finalhandler": "0.1.0",
+        "fresh": "0.2.2",
+        "media-typer": "0.2.0",
+        "method-override": "2.1.3",
+        "morgan": "1.2.3",
+        "multiparty": "3.3.2",
+        "on-headers": "1.0.1",
+        "parseurl": "1.3.2",
+        "pause": "0.0.1",
+        "qs": "2.2.2",
+        "response-time": "2.0.1",
+        "serve-favicon": "2.0.1",
+        "serve-index": "1.1.6",
+        "serve-static": "1.5.4",
+        "type-is": "1.3.2",
+        "vhost": "2.0.0"
+      }
+    },
+    "connect-timeout": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.2.2.tgz",
+      "integrity": "sha1-WVNgK7Zqv9X6Ia6RGnIhxeglocA=",
+      "requires": {
+        "debug": "1.0.4",
+        "ms": "0.6.2",
+        "on-headers": "1.0.1"
+      }
+    },
+    "cookie": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz",
+      "integrity": "sha1-cv7D0k5Io0Mgc9kMEmQgBQYQBLE="
+    },
+    "cookie-parser": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.2.tgz",
+      "integrity": "sha1-UiEcyCyVXXn/DAiJVEB3JOGc9WI=",
+      "requires": {
+        "cookie": "0.1.2",
+        "cookie-signature": "1.0.4"
+      }
+    },
+    "cookie-signature": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.4.tgz",
+      "integrity": "sha1-Dt0iKG46ERuaKnDbNj6SXoZ/aso="
+    },
+    "cookiejar": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
+      "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "csrf": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/csrf/-/csrf-2.0.7.tgz",
+      "integrity": "sha1-0E9S4Paiin4s/h4B3V68JRs9QgE=",
+      "requires": {
+        "base64-url": "1.2.1",
+        "rndm": "1.1.1",
+        "scmp": "1.0.0",
+        "uid-safe": "1.1.0"
+      }
+    },
+    "csurf": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.4.1.tgz",
+      "integrity": "sha1-DMrwJpkrLSGHcdYXT1xsQCpiif0=",
+      "requires": {
+        "cookie": "0.1.2",
+        "cookie-signature": "1.0.4",
+        "csrf": "2.0.7"
+      }
+    },
+    "debug": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
+      "integrity": "sha1-W5wla9VLbsAigxdvqKDt5tFUy/g=",
+      "requires": {
+        "ms": "0.6.2"
+      }
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "dev": true,
+      "requires": {
+        "type-detect": "0.1.1"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+          "dev": true
+        }
+      }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      }
+    },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "depd": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-0.4.4.tgz",
+      "integrity": "sha1-BwkfrnX5eCjYm0oCotR3jw58BmI="
+    },
+    "destroy": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz",
+      "integrity": "sha1-tDO0ck5x/YVR2YhRdIUcX8N34sk="
+    },
+    "ee-first": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz",
+      "integrity": "sha1-jJshKJjYzZ8alDZlDOe+ICyen/A="
+    },
+    "errorhandler": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.1.1.tgz",
+      "integrity": "sha1-GN79Q22Mou/gotiGxcTW7m121pE=",
+      "requires": {
+        "accepts": "1.0.7",
+        "escape-html": "1.0.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.9.0.tgz",
+      "integrity": "sha512-kk3IJoKo7A3pWJc0OV8yZ/VEX2oSUytfekrJiqoxBlKJMFAJVJVpGdHClCCTdv+Fn2zHfpDHHIelMFhZVfef3Q==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "dev": true,
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
+      }
+    },
+    "escape-html": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz",
+      "integrity": "sha1-GBoobq05ejmpKFfPsdQwUuNWv/A="
+    },
+    "express": {
+      "version": "3.16.10",
+      "resolved": "https://registry.npmjs.org/express/-/express-3.16.10.tgz",
+      "integrity": "sha1-xoxaww6eiQuBLBFAjc3hg8QRu1Y=",
+      "requires": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "commander": "1.3.2",
+        "connect": "2.25.10",
+        "cookie": "0.1.2",
+        "cookie-signature": "1.0.4",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "fresh": "0.2.2",
+        "media-typer": "0.2.0",
+        "merge-descriptors": "0.0.2",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "1.3.2",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.8.5",
+        "vary": "0.1.0"
+      }
+    },
+    "express-session": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.7.6.tgz",
+      "integrity": "sha1-4cNpuiF296/beed9ZdzYx8RuSKU=",
+      "requires": {
+        "buffer-crc32": "0.2.3",
+        "cookie": "0.1.2",
+        "cookie-signature": "1.0.4",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "on-headers": "1.0.1",
+        "parseurl": "1.3.2",
+        "uid-safe": "1.0.1",
+        "utils-merge": "1.0.0"
+      },
+      "dependencies": {
+        "uid-safe": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.0.1.tgz",
+          "integrity": "sha1-W9FIRgouhPVPGT/SA1LIw9feasg=",
+          "requires": {
+            "base64-url": "1.2.1",
+            "mz": "1.3.0"
+          }
+        }
+      }
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
+    },
+    "finalhandler": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.1.0.tgz",
+      "integrity": "sha1-2gW7xPX0owyEzh2R88FUAHxOnao=",
+      "requires": {
+        "debug": "1.0.4",
+        "escape-html": "1.0.1"
+      }
+    },
+    "for-each": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
+      "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
+      "dev": true,
+      "requires": {
+        "is-function": "1.0.1"
+      }
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "dev": true,
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.17"
+      },
+      "dependencies": {
+        "mime-types": {
+          "version": "2.1.17",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+          "dev": true,
+          "requires": {
+            "mime-db": "1.30.0"
+          }
+        }
+      }
+    },
+    "formidable": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz",
+      "integrity": "sha1-lriIb3w8NQi5Mta9cMTTqI818ak=",
+      "dev": true
+    },
+    "fresh": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz",
+      "integrity": "sha1-lzHc9WeMf660T7kDxPct9VGH+nc="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "has": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.1"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.4.tgz",
+      "integrity": "sha1-6V8uQdsHNfwhZS94J6XuMuY8g6g="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ipaddr.js": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.2.tgz",
+      "integrity": "sha1-ah/T2FT1ACllw017vNm0qNSwRn4="
+    },
+    "is-callable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
+    "is-function": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "1.0.1"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "keypress": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
+      "integrity": "sha1-SjGI1CkbZrT2XtuZ+AaqmuKTWSo="
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "dev": true
+    },
+    "media-typer": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.2.0.tgz",
+      "integrity": "sha1-2KBlITrf6qLnYyGitt2jb/YzWYQ="
+    },
+    "merge-descriptors": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz",
+      "integrity": "sha1-w2pSp4FDdRPFcnXzndnTF1FKyMc="
+    },
+    "method-override": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.1.3.tgz",
+      "integrity": "sha1-UR9BxPsdzNtqsYRNpdxuqBt8ETU=",
+      "requires": {
+        "debug": "1.0.4",
+        "methods": "1.1.0",
+        "parseurl": "1.3.2",
+        "vary": "1.0.1"
+      },
+      "dependencies": {
+        "vary": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
+          "integrity": "sha1-meSYFWaihhGN+yuBc1ffeZM3bRA="
+        }
+      }
+    },
+    "methods": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.0.tgz",
+      "integrity": "sha1-XcpO4S31L/OwVhRZhqjwHLyGQ28="
+    },
+    "mime": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+      "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
+    },
+    "mime-db": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+      "integrity": "sha1-mVrhOSq4r/y/yyZB3QVOlDwNXc4="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+      "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "morgan": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.2.3.tgz",
+      "integrity": "sha1-Ow8XBN+QJVpUJZGrrNeXiRqMQKE=",
+      "requires": {
+        "basic-auth": "1.0.0",
+        "bytes": "1.0.0",
+        "depd": "0.4.4",
+        "on-finished": "2.1.0"
+      }
+    },
+    "ms": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+      "integrity": "sha1-2JwhJMb9wTU9Zai3e/GqxLGTcIw="
+    },
+    "multiparty": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
+      "integrity": "sha1-Nd5oBNwZZD5SSfPT473GyM4wHT8=",
+      "requires": {
+        "readable-stream": "1.1.14",
+        "stream-counter": "0.2.0"
+      }
+    },
+    "mz": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-1.3.0.tgz",
+      "integrity": "sha1-BvCT/dmVagbTfhsegTROJ0eMQvA=",
+      "requires": {
+        "native-or-bluebird": "1.1.2",
+        "thenify": "3.3.0",
+        "thenify-all": "1.6.0"
+      }
+    },
+    "native-or-bluebird": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.1.2.tgz",
+      "integrity": "sha1-OSHhECMtHreQ89rGG7NwUxx9NW4="
+    },
+    "negotiator": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.7.tgz",
+      "integrity": "sha1-pBYPcXfsgGc4Yx0NMFIyXaQqvcg="
+    },
+    "nock": {
+      "version": "9.0.27",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-9.0.27.tgz",
+      "integrity": "sha512-UCdl4VFGBrnNLgk4Rx2NKjPbzVVk6BSsG4xjDhPcKwWwHWVxYT/TcuCT/9ObG46ez5d/jg7+4EFbPuF3XjDRtQ==",
+      "dev": true,
+      "requires": {
+        "chai": "3.5.0",
+        "debug": "2.6.9",
+        "deep-equal": "1.0.1",
+        "json-stringify-safe": "5.0.1",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.0",
+        "propagate": "0.4.0",
+        "qs": "6.5.1",
+        "semver": "5.4.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+          "dev": true
+        }
+      }
+    },
+    "object-inspect": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.3.0.tgz",
+      "integrity": "sha512-OHHnLgLNXpM++GnJRyyhbr2bwl3pPVm4YvaraHrRvDt/N3r+s/gDVHciA7EJBTkijKXj61ssgSAikq1fb0IBRg==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "dev": true
+    },
+    "on-finished": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
+      "integrity": "sha1-DFOfCSkej/rd4MiiWFD7LO3HAi0=",
+      "requires": {
+        "ee-first": "1.0.5"
+      }
+    },
+    "on-headers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
+    "pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
+    },
+    "propagate": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.4.0.tgz",
+      "integrity": "sha1-8/zKCm/gZzanulcpZgaWF8EwtIE=",
+      "dev": true
+    },
+    "proxy-addr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.1.tgz",
+      "integrity": "sha1-x8Vm1etOP61n7rnHfFVYzMObiKg=",
+      "requires": {
+        "ipaddr.js": "0.1.2"
+      }
+    },
+    "qs": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-2.2.2.tgz",
+      "integrity": "sha1-3+eD8YVLGsKzreknda0D4n4DIYw="
+    },
+    "range-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.0.tgz",
+      "integrity": "sha1-pLJkz+C+XONqvjdlrJwqJIdG28A="
+    },
+    "raw-body": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.0.tgz",
+      "integrity": "sha1-l4IwoValVI9C7vFN4i0PT2EAg9E=",
+      "requires": {
+        "bytes": "1.0.0",
+        "iconv-lite": "0.4.4"
+      }
+    },
+    "readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "0.0.1",
+        "string_decoder": "0.10.31"
+      }
+    },
+    "resolve": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "response-time": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.0.1.tgz",
+      "integrity": "sha1-xtLLrerEyyUbIQFv4YJkDAKv80M=",
+      "requires": {
+        "on-headers": "1.0.1"
+      }
+    },
+    "resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
+    "rndm": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.1.1.tgz",
+      "integrity": "sha1-7870N0Ah94tj3mImtZhRICadZPE="
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
+    },
+    "scmp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/scmp/-/scmp-1.0.0.tgz",
+      "integrity": "sha1-oLJyw/xykvdxFWRvAGGLAmJRTgQ="
+    },
+    "semver": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "dev": true
+    },
+    "send": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.8.5.tgz",
+      "integrity": "sha1-N/cIIW5vUMF150xp/sU0hOL9gsc=",
+      "requires": {
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "on-finished": "2.1.0",
+        "range-parser": "1.0.0"
+      }
+    },
+    "serve-favicon": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.0.1.tgz",
+      "integrity": "sha1-SCaXXZ8XPKOkFY6WmBYfdd7Hr+w=",
+      "requires": {
+        "fresh": "0.2.2"
+      }
+    },
+    "serve-index": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.1.6.tgz",
+      "integrity": "sha1-t1gxj+eBYoOD9mrIDdRHcS6neB8=",
+      "requires": {
+        "accepts": "1.0.7",
+        "batch": "0.5.1",
+        "parseurl": "1.3.2"
+      }
+    },
+    "serve-static": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.5.4.tgz",
+      "integrity": "sha1-gZ+zeuRr0C3VILd/z3/Y9REvl4I=",
+      "requires": {
+        "escape-html": "1.0.1",
+        "parseurl": "1.3.2",
+        "send": "0.8.5",
+        "utils-merge": "1.0.0"
+      }
+    },
+    "stream-counter": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz",
+      "integrity": "sha1-3tJmVWMZyLDiIoErnPOyb6fZR94=",
+      "requires": {
+        "readable-stream": "1.1.14"
+      }
+    },
+    "string.prototype.trim": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.9.0",
+        "function-bind": "1.1.1"
+      }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "superagent": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.0.tgz",
+      "integrity": "sha512-71XGWgtn70TNwgmgYa69dPOYg55aU9FCahjUNY03rOrKvaTCaU3b9MeZmqonmf9Od96SCxr3vGfEAnhM7dtxCw==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "1.2.1",
+        "cookiejar": "2.1.1",
+        "debug": "3.1.0",
+        "extend": "3.0.1",
+        "form-data": "2.3.1",
+        "formidable": "1.1.1",
+        "methods": "1.1.2",
+        "mime": "1.4.1",
+        "qs": "6.5.1",
+        "readable-stream": "2.3.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "methods": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+          "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+          "dev": true
+        },
+        "mime": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
+    "supertest": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-3.0.0.tgz",
+      "integrity": "sha1-jUu2j9GDDuBwM7HFpamkAhyWUpY=",
+      "dev": true,
+      "requires": {
+        "methods": "1.1.2",
+        "superagent": "3.8.0"
+      },
+      "dependencies": {
+        "methods": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+          "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+          "dev": true
+        }
+      }
+    },
+    "tape": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.8.0.tgz",
+      "integrity": "sha512-TWILfEnvO7I8mFe35d98F6T5fbLaEtbFTG/lxWvid8qDfFTxt19EBijWmB4j3+Hoh5TfHE2faWs73ua+EphuBA==",
+      "dev": true,
+      "requires": {
+        "deep-equal": "1.0.1",
+        "defined": "1.0.0",
+        "for-each": "0.3.2",
+        "function-bind": "1.1.1",
+        "glob": "7.1.2",
+        "has": "1.0.1",
+        "inherits": "2.0.3",
+        "minimist": "1.2.0",
+        "object-inspect": "1.3.0",
+        "resolve": "1.4.0",
+        "resumer": "0.0.0",
+        "string.prototype.trim": "1.1.2",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "thenify": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
+      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+      "requires": {
+        "any-promise": "1.3.0"
+      }
+    },
+    "thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+      "requires": {
+        "thenify": "3.3.0"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "type-detect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "dev": true
+    },
+    "type-is": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.3.2.tgz",
+      "integrity": "sha1-TypdxYd1yhYwJQr8cYb4s2MJ0bs=",
+      "requires": {
+        "media-typer": "0.2.0",
+        "mime-types": "1.0.2"
+      }
+    },
+    "uid-safe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.1.0.tgz",
+      "integrity": "sha1-WNbF2r+N+9jVKDSDmAbAP9YUMjI=",
+      "requires": {
+        "base64-url": "1.2.1",
+        "native-or-bluebird": "1.1.2"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "utils-merge": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+    },
+    "vary": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-0.1.0.tgz",
+      "integrity": "sha1-3wlFiZ6TwMxb0YzIMh2dIedPYXY="
+    },
+    "vhost": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vhost/-/vhost-2.0.0.tgz",
+      "integrity": "sha1-HiZ3C9D86GxAlFWR5vKExokXkeI="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "oauth"
   ],
   "scripts": {
-      "start": "node server.js"
+    "start": "node index.js",
+    "test": "node tests/server.test.js"
   },
   "repository": {
     "type": "git",
@@ -22,5 +23,10 @@
     "node": "~6.11.1"
   },
   "main": "index",
-  "version": "0.1.0"
+  "version": "0.1.0",
+  "devDependencies": {
+    "nock": "^9.0.27",
+    "supertest": "^3.0.0",
+    "tape": "^4.8.0"
+  }
 }

--- a/server.js
+++ b/server.js
@@ -103,11 +103,5 @@ app.get('/authenticate/:code', function(req, res) {
   });
 });
 
-// var port = process.env.PORT || config.port || 9999;
-//
-// app.listen(port, null, function (err) {
-//   log('Gatekeeper, at your service: http://localhost:' + port);
-// });
-
 module.exports.config = config;
 module.exports.app = app;

--- a/server.js
+++ b/server.js
@@ -103,8 +103,11 @@ app.get('/authenticate/:code', function(req, res) {
   });
 });
 
-var port = process.env.PORT || config.port || 9999;
+// var port = process.env.PORT || config.port || 9999;
+//
+// app.listen(port, null, function (err) {
+//   log('Gatekeeper, at your service: http://localhost:' + port);
+// });
 
-app.listen(port, null, function (err) {
-  log('Gatekeeper, at your service: http://localhost:' + port);
-});
+module.exports.config = config;
+module.exports.app = app;

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const test = require('tape');
+const request = require('supertest');
+const nock = require('nock');
+
+const { app } = require('../server');
+
+// mock a valid GH auth response
+nock('https://github.com/')
+.post('/login/oauth/access_token', () => true)
+.reply(200, 'access_token=mockedToken&token_type=bearer');
+
+test('handle valid code', (t) =>
+  request(app)
+    .get('/authenticate/good_code')
+    .expect('Content-Type', /json/)
+    .expect(200)
+    .end((err, res) => {
+      t.deepEqual(res.body, {token: 'mockedToken'}, 'Should response with token when code is valid');
+      t.end();
+    })
+);
+
+// mock an invalid GH auth response
+nock('https://github.com/')
+.post('/login/oauth/access_token', () => true)
+.reply(200, 'error=bad_verification_code&error_description=The+code+passed+is+incorrect+or+expired.&error_uri=https%3A%2F%2Fdeveloper.github.com%2Fv3%2Foauth%2F%23bad-verification-code');
+
+test('handle bad code', (t) =>
+  request(app)
+    .get('/authenticate/bad_code')
+    .expect('Content-Type', /json/)
+    .expect(200)
+    .end((err, res) => {
+      t.deepEqual(res.body, { error: 'bad_code' }, 'Should not auth with a bad code');
+      t.end();
+    })
+);


### PR DESCRIPTION
This PR belongs to issue #40.
Added a basic test suite was added using [tape](https://github.com/substack/tape) and [supertest](https://github.com/visionmedia/supertest).

GitHub API responses where mocked with [nock](https://github.com/node-nock/nock).

As a start, I added test cases for calls to the `authenticate` route with a valid and an invalid GH code.

Note: in order for supertest to work, we have to export the express app before it is bound to any port. That's why I refactored the listen call in an extra `index.js` file, which requires `server.js` and gets picked up by `npm start`.

How to run:
 - Install new dependencies: `npm install`
 - Run test: `npm run test`

Any further suggestions?