### PR TITLE
Fix serve instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Also see the [documentation on Github](http://developer.github.com/v3/oauth/).
 4. Serve it
 
    ```
-   $ node server.js
+   $ node index.js
    ```
 
 ## Deploy on Heroku


### PR DESCRIPTION
It looks like this change requires us to run `node index.js` to run the server:
https://github.com/prose/gatekeeper/commit/f6c578e821a8ea775c429ea9ff3c8dae4078b324#diff-168726dbe96b3ce427e7fedce31bb0bc
It certainly had me scratching my head for a few minutes... Ok tens of minutes :-)