### PR TITLE
fix bad_code error when vars contain whitespace

### DIFF
--- a/server.js
+++ b/server.js
@@ -16,7 +16,7 @@ function loadConfig() {
   var config = JSON.parse(fs.readFileSync(__dirname+ '/config.json', 'utf-8'));
   log('Configuration');
   for (var i in config) {
-    config[i] = process.env[i.toUpperCase()] || config[i];
+    config[i] = (process.env[i.toUpperCase()] || config[i]).trim();
     if (i === 'oauth_client_id' || i === 'oauth_client_secret') {
       log(i + ':', config[i], true);
     } else {


### PR DESCRIPTION
## Summary
When creating a new heroku server it is possible to accidentally include whitespace when pasting your token, this fixes that issue.